### PR TITLE
[Improvement ] - replace "case" with "description" 

### DIFF
--- a/mobile/src/pages/Detail/index.js
+++ b/mobile/src/pages/Detail/index.js
@@ -56,8 +56,8 @@ export default function Detail() {
           {incident.name} de {incident.city}/{incident.uf}
         </Text>
 
-        <Text style={styles.incidentProperty}>CASO:</Text>
-        <Text style={styles.incidentValue}>{incident.title}</Text>
+        <Text style={styles.incidentProperty}>DESCRIÇÃO:</Text>
+        <Text style={styles.incidentValue}>{incident.description}</Text>
 
         <Text style={styles.incidentProperty}>VALOR:</Text>
         <Text style={styles.incidentValue}>


### PR DESCRIPTION
# Motivation:

The description field belongs to the details screen.

_______________________________________________________________________________________________________

# Solution:

As the description field was not added on the screen, I opened this pull request to contribute to the application

_______________________________________________________________________________________________________

# Assignment:

- [x] Replace the "case" field with "description" and the "incident.tile" field with "incident.description"
